### PR TITLE
Allow for bookmark names to be passed in via key binding

### DIFF
--- a/sublimebookmark.py
+++ b/sublimebookmark.py
@@ -65,7 +65,7 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 		self._Load()
 
 
-	def run(self, type):
+	def run(self, type, name=None):
 		global BOOKMARKS_MODE
 
 		self.activeGroup = self.window.active_group()	
@@ -78,7 +78,7 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 		self._UpdateTemporaryBookmarks()
 
 		if type == "add":
-			self._addBookmark()
+			self._addBookmark(name)
 
 		elif type == "goto":
 			#on highlighting, goto the current bookmark
@@ -175,19 +175,21 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 	
 
 	#event handlers----------------------------
-	def _addBookmark(self):
+	def _addBookmark(self, name):
 		Log ("add")
 
-		window = self.window
-		view = window.active_view()
-		region = getCurrentLineRegion(view)
+		if name is None:
+			window = self.window
+			view = window.active_view()
+			region = getCurrentLineRegion(view)
 
-		#copy whatever is on the line for the bookmark name
-		initialText = view.substr(region).strip()
+			#copy whatever is on the line for the bookmark name
+			initialText = view.substr(region).strip()
 
-		input = OptionsInput(self.window, "Add Bookmark", initialText, self._AddBookmarkCallback, None)
-		input.start()
-
+			input = OptionsInput(self.window, "Add Bookmark", initialText, self._AddBookmarkCallback, None)
+			input.start()
+		else:
+			self._AddBookmarkCallback(name)
 
 
 	def _removeAllBookmarks(self):


### PR DESCRIPTION
Hi,

A small change which allows me to bind keys to specific named bookmarks (e.g. Alt-0 .. Alt-9) to mimic functionality I'm used to in SlickEdit. If no name argument is passed in, it uses the old behaviour of using the currently selected text, else it uses the name.

I had some confusion on an earlier pull request which added quick bookmarks and which had code changes in the same area? I'm new to git, to I _think_ I based this on the most current version...
