### PR TITLE
remove trailing comma

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -7,5 +7,5 @@
   	"caption": "Add bookmark",
     "command": "sublime_bookmark",
      "args" : { "type" : "add" }
-  }, 
+  } 
 ]


### PR DESCRIPTION
this comma brakes loading of context.s-menu in st2 with **Unable to parse value: Trailing comma before closing bracket at /C/Portable/Sublime Text 2/Data/Packages/Sublime Bookmarks/Context.sublime-menu:10:0** error.
