### PR TITLE
Added 'goto' shortcut in the sublime-keymap.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
-[  
+[
 	{ "keys": ["ctrl+shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "add"  } },
     { "keys": ["f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_next" } },
-	{ "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_prev" } },
+	{ "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_previous" } },
+    { "keys": ["alt+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
 	{ "keys": ["ctrl+f2"], "command": "sublime_bookmark", "args" : { "type" : "toggle_line"  } }
-]  
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["super+shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "add"  } },
     { "keys": ["f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_next" } },
-    { "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_prev" } },
+    { "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_previous" } },
+    { "keys": ["cmd+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
     { "keys": ["super+f2"], "command": "sublime_bookmark", "args" : { "type" : "toggle_line"  } }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,7 +1,7 @@
 [
 	{ "keys": ["ctrl+shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "add"  } },
     { "keys": ["f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_next" } },
-	{ "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_prev" } },
+	{ "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_previous" } },
     { "keys": ["alt+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
 	{ "keys": ["ctrl+f2"], "command": "sublime_bookmark", "args" : { "type" : "toggle_line"  } }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
-[  
+[
 	{ "keys": ["ctrl+shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "add"  } },
     { "keys": ["f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_next" } },
 	{ "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_prev" } },
+    { "keys": ["alt+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
 	{ "keys": ["ctrl+f2"], "command": "sublime_bookmark", "args" : { "type" : "toggle_line"  } }
-]  
+]

--- a/sublimebookmark.py
+++ b/sublimebookmark.py
@@ -198,7 +198,8 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 		global BOOKMARKS
 		global ERASED_BOOKMARKS
 
-		for bookmark in BOOKMARKS:
+		visibles = getVisibleBookmarks(BOOKMARKS, self.window, self.activeView, BOOKMARKS_MODE)			
+		for bookmark in visibles:
 			#store erased bookmarks for delayed removal
 			ERASED_BOOKMARKS.append(deepcopy(bookmark))
 			


### PR DESCRIPTION
The 'goto' shortcut is really handy, and it avoid people to wander through github to find it !
I didn't try the shortcut on Mac OS or Windows, but they should work.

Personally I don't like the F2 shortcut cause this touch is toooo far away on the keyboard for file navigation. But that's a matter of taste.

Also as mentioned in another PR, the correct command is "goto_previous" and not "goto_prev".

Anyway, thanks for this great plugin which should definitively be included in the official sublime version :-)