### PR TITLE
Update Default (OSX).sublime-keymap -- use "alt" not "cmd" for ST3.

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,6 +2,6 @@
     { "keys": ["super+shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "add"  } },
     { "keys": ["f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_next" } },
     { "keys": ["shift+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto_previous" } },
-    { "keys": ["cmd+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
+    { "keys": ["alt+f2"], "command": "sublime_bookmark", "args" : { "type" : "goto" } },
 	{ "keys": ["super+f2"], "command": "sublime_bookmark", "args" : { "type" : "toggle_line"  } }
 ]


### PR DESCRIPTION
Use "alt" instead of "cmd" -- for some reason this is what ST3 looks for on OSX.
(Using build 3083.)
