### PR TITLE
fix incorrect bookmark order in goto next/prev

### DIFF
--- a/sublimebookmark.py
+++ b/sublimebookmark.py
@@ -153,7 +153,8 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 			return True
 
 		#load all visible bookmarks
-		self.displayedBookmarks = getVisibleBookmarks(BOOKMARKS, self.window, self.activeView, BOOKMARKS_MODE)
+		self.displayedBookmarks = getVisibleBookmarks(BOOKMARKS, self.window, self.activeView,
+			BOOKMARKS_MODE, activeFileFirst=True)
 			
 		#if no bookmarks are acceptable, don't show bookmarks
 		if len(self.displayedBookmarks) == 0:
@@ -214,7 +215,9 @@ class SublimeBookmarkCommand(sublime_plugin.WindowCommand):
 
 	def _quickGoto(self, forward):
 		# Gather appropriate bookmarks
-		self.displayedBookmarks = getVisibleBookmarks(BOOKMARKS, self.window, self.activeView, BOOKMARKS_MODE)
+		# Do not order by active file name because we need global order.
+		self.displayedBookmarks = getVisibleBookmarks(BOOKMARKS, self.window, self.activeView,
+			BOOKMARKS_MODE, activeFileFirst=False)
 
 		if 0 == len(self.displayedBookmarks):
 			MESSAGE_NoBookmarkToGoto()

--- a/visibilityHandler.py
+++ b/visibilityHandler.py
@@ -72,16 +72,16 @@ def ___sortBookmarks(visibleBookmarks, currentFile):
 		sortedBookmarks = sortedBookmarks + sortedBookmarkList
 
 
-	print (sortedBookmarks)
 	return sortedBookmarks
 
 
 
-def getVisibleBookmarks(bookmarks, window, activeView, bookmarkMode):
+def getVisibleBookmarks(bookmarks, window, activeView, bookmarkMode, activeFileFirst):
 	visibleBookmarks = []
 	for bookmark in bookmarks:
 		if shouldShowBookmark(window, activeView, bookmark, bookmarkMode):
 			visibleBookmarks.append(bookmark)
 
-	sortedBookmarks = ___sortBookmarks(visibleBookmarks, activeView.file_name())
-	return sortedBookmarks
+	if activeFileFirst:
+		visibleBookmarks = ___sortBookmarks(visibleBookmarks, activeView.file_name())
+	return visibleBookmarks


### PR DESCRIPTION
Hi,

Thank you for the great plugin!

There is an issue with incorrect bookmark switch order when next/previous bookmaker called.
How  to reproduce (used Sublime Text 3 build 3126 on macOS):
1. Open two files
2. Add first bookmark in one file, and second in another file. 
3. Run "SublimeBookmarks: Goto Next Bookmark" multiple time.
Result: Near half of the commands do not result in bookmark switch.

This pull request fixes this issue. Thanks!